### PR TITLE
Update module.json to PackageAuthorData format

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,7 +3,12 @@
    "name": "jaamod",
    "title": "Jinker's Animated Art Pack",
    "description": "<p>Collection of Animated Art for use with VTT's in the top-down/overhead perspective. All files are in transparent webm format. Files will be located in your <code>Data/modules/jaamod/AnimatedArt</code> folder.</p><p>If you like my work consider becoming a <a title='Jinker&#39;s Patreon' href='https://www.patreon.com/jinker'>Patron</a> to ensure I keep creating content for Foundry. <a title='jinker.org preview page' href='http://www.jinker.org/patreon/'>Preview Page</a></p>",
-   "authors": "Jinker (Jinker#8073)",
+   "authors": [
+      {
+         "name": "Jinker",
+         "discord": "Jinker#8073"
+      }
+   ],
    "version": "0.8",
    "minimumCoreVersion": "0.7.0",
    "compatibleCoreVersion": "10",


### PR DESCRIPTION
[jaamod] The module "jaamod" provides an "authors" array containing string elements which is deprecated in favor of using PackageAuthorData objects

https://foundryvtt.com/api/interfaces/foundry.packages.PackageAuthorData.html